### PR TITLE
v1.1.2

### DIFF
--- a/get-costofretiringresources.ps1
+++ b/get-costofretiringresources.ps1
@@ -78,8 +78,8 @@ function Get-ResourceCost($resourceId, $billingPeriodStart, $billingPeriodEnd, $
         $response = Invoke-RestMethod -Uri $uri -Method Post -SkipHttpErrorCheck -StatusCodeVariable "statusCode" -ResponseHeadersVariable "responseHeaders" -Body $jsonPayload -Headers @{
             'Authorization' = "Bearer $token"
             'Content-Type'  = 'application/json'
+            "Client-Type"   = "GetCostOfRetiringResources"
         }
-        #             "Client-Type"   = "Get-CostOfRetiringResources.ps1"
 
         if ($statusCode -eq 429) {
             $qpuRetryAfter = [double]::Parse($responseHeaders['x-ms-ratelimit-microsoft.costmanagement-client-qpu-retry-after'] ?? 0)
@@ -93,7 +93,7 @@ function Get-ResourceCost($resourceId, $billingPeriodStart, $billingPeriodEnd, $
                 $retryAfter = 30    # if none of the above is set, assume a delay of 30 seconds. Otherwise use the maximum of the values
             }
 
-            write-host -ForegroundColor DarkYellow "wait (${retryAfter})... " -NoNewline
+            write-host -ForegroundColor DarkYellow "wait ${retryAfter}s... " -NoNewline
             Start-Sleep -Seconds $retryAfter
         }
         elseif ($statusCode -ne 200) {

--- a/get-costofretiringresources.ps1
+++ b/get-costofretiringresources.ps1
@@ -70,7 +70,7 @@ function Get-ResourceCost($resourceId, $billingPeriodStart, $billingPeriodEnd, $
 
     $cost = 0
 
-    # send the request. Handle errors 429 (too many requests) by waiting 30 seconds and retrying
+    # send the request. Handle errors 429 (too many requests)
     do {
         $requestCompleted = $false
         $statusCode = 0
@@ -85,12 +85,11 @@ function Get-ResourceCost($resourceId, $billingPeriodStart, $billingPeriodEnd, $
             $qpuRetryAfter = [double]::Parse($responseHeaders['x-ms-ratelimit-microsoft.costmanagement-client-qpu-retry-after'] ?? 0)
             $clientRetryAfter = [double]::Parse($responseHeaders['x-ms-ratelimit-microsoft.costmanagement-client-retry-after'] ?? 0)
             $tenantRetryAfter = [double]::Parse($responseHeaders['x-ms-ratelimit-microsoft.costmanagement-tenant-retry-after'] ?? 0)
-            $entityRetryAfter = [double]::Parse($responseHeaders['x-ms-ratelimit-microsoft.costmanagement-entity-retry-after'] ?? 0)
-            
+            $entityRetryAfter = [double]::Parse($responseHeaders['x-ms-ratelimit-microsoft.costmanagement-entity-retry-after'] ?? 0)            
             $retryAfterSet = @($qpuRetryAfter, $clientRetryAfter, $tenantRetryAfter, $entityRetryAfter)
-            $retryAfter = $retryAfterSet | Sort-Object -Descending | Select-Object -First 1
+            $retryAfter = $retryAfterSet | Sort-Object -Descending | Select-Object -First 1 # get the maximum value of the retry-after values
             if ($retryAfter -eq 0) {
-                $retryAfter = 30    # if none of the above is set, assume a delay of 30 seconds. Otherwise use the maximum of the values
+                $retryAfter = 30    # if none of the above is set, assume a delay of 30 seconds
             }
 
             write-host -ForegroundColor DarkYellow "wait ${retryAfter}s... " -NoNewline


### PR DESCRIPTION
Key changes:

* [`get-costofretiringresources.ps1`](diffhunk://#diff-1b945436cdfbe1a973517372dccd70369416799c581fd0097eaeebbd2a196b46L10-L20): A new `Get-ResourceCost` function was added to calculate the cost of retiring resources within a given billing period. The main script was refactored to use the new `Get-ResourceCost` function. This refactoring also included changes to the handling and display of resource count, total cost, and cumulative costs by resource type.

* more accurate handling of throttling replies from API